### PR TITLE
Updating the chair and tech lead folder's readme for monthly meeting time.

### DIFF
--- a/contributors/chairs-and-techleads/README.md
+++ b/contributors/chairs-and-techleads/README.md
@@ -21,7 +21,9 @@ TODO
 
 Communication and feedback loops:  
 [Need to Know email archive]  
-[Monthly meeting]  
+[Monthly meeting]
+The chair and tech lead monthly meeting schedule: 2nd Tuesday and Thursday of the month at 730pm UTC and 430pm UTC respectively.
+
 Slack: #chairs-and-techleads, #sig-contribex  
 Mailing list: kubernetes-sig-leads@googlegroups.com  
 Github: File issues against kubernetes/community  


### PR DESCRIPTION
Adding the chair and tech lead monthly meeting time without the zoom information at line 25 in README.md
 Fixes #4677

